### PR TITLE
Fix get command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.vscode/

--- a/restlauncher.go
+++ b/restlauncher.go
@@ -53,7 +53,7 @@ var get = &cli.Command{
 	Argv: func() interface{} { return new(argGet) },
 	Fn: func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argGet)
-		res := call("Get", argv.Url, nil, argv.Header)
+		res := call("GET", argv.Url, nil, argv.Header)
 		printStatus(res)
 		printHeader(res)
 		fmt.Println()


### PR DESCRIPTION
Get is lowercase typo instead of uppercase. This commit fix it.